### PR TITLE
feat: add theme switcher and glass styles

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -14,7 +14,7 @@ If you'd like to help, pick an item or suggest a new one.
 ## Upcoming
 
 ### Global Features
-- [ ] Implement dark/light/sepia theme switcher and glass UI
+- [x] Implement dark/light/sepia theme switcher and glass UI
 - [ ] Add design editor with presets, font switcher, and JSON import/export
 - [ ] Integrate cookie consent, announcement bar, visitor counter, analytics, keyboard hints
 - [ ] Provide global search, RSS link, QR code, donate button, reading progress indicator and back-to-top button

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,16 +5,33 @@ interface Props {
   children: ReactNode;
 }
 
-const Layout = ({ children }: Props) => {
-  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
+type Theme = 'dark' | 'light' | 'sepia';
 
+const Layout = ({ children }: Props) => {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  // load initial theme from storage
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    }
+  }, []);
+
+  // apply theme and persist changes
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
+    localStorage.setItem('theme', theme);
   }, [theme]);
+
+  const nextTheme = (t: Theme): Theme =>
+    t === 'dark' ? 'light' : t === 'light' ? 'sepia' : 'dark';
+
+  const upcoming = nextTheme(theme);
 
   return (
     <>
-      <header className="header">
+      <header className="header glass">
         <nav className="nav">
           <span className="logo">Almir</span>
           <ul className="links">
@@ -24,9 +41,9 @@ const Layout = ({ children }: Props) => {
           </ul>
           <button
             className="theme-toggle"
-            onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            onClick={() => setTheme(upcoming)}
           >
-            {theme === 'dark' ? 'Light' : 'Dark'} mode
+            Switch to {upcoming} mode
           </button>
         </nav>
       </header>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,6 +8,11 @@ html[data-theme='light'] {
   color: #111;
 }
 
+html[data-theme='sepia'] {
+  background: #f4ecd8;
+  color: #5b4636;
+}
+
 body {
   margin: 0;
   font-family: sans-serif;
@@ -16,12 +21,20 @@ body {
 .header {
   position: sticky;
   top: 0;
-  backdrop-filter: blur(8px);
-  background: rgba(0,0,0,0.4);
   padding: 0.5rem 1rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+.glass {
+  backdrop-filter: blur(8px);
+  background: rgba(0, 0, 0, 0.4);
+}
+
+html[data-theme='light'] .glass,
+html[data-theme='sepia'] .glass {
+  background: rgba(255, 255, 255, 0.4);
 }
 
 .nav .links {


### PR DESCRIPTION
## Summary
- add persistent theme switcher cycling dark, light and sepia modes
- introduce reusable glass styling and apply it to header
- mark theme-switcher task complete

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f1dd3e5483299c44799780bca1fc