### PR TITLE
feat: add hero section with contact icons

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -25,7 +25,7 @@ If you'd like to help, pick an item or suggest a new one.
 - [ ] Support left-side timeline markers and menu hover animations
 
 ### Content Sections
-- [ ] Build hero section with contact buttons and random quote
+- [x] Build hero section with contact buttons and random quote
 - [ ] Write About and Mission/Vision content with optional photo
 - [ ] Implement Skills & Languages section with categories, levels, badges and radar chart
 - [ ] Develop Projects cards, show-more/all-projects links and env-driven placeholders

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "next": "^15.5.3",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"c
+    "react-dom": "^19.1.1",
+    "lucide-react": "^0.453.0"
   },
   "devDependencies": {
     "@types/node": "^24.4.0",

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import {
+  Mail,
+  Send,
+  MessageCircle,
+  Facebook,
+  Gamepad2,
+  Github
+} from 'lucide-react';
+import { useDesignContext } from '../context/DesignContext';
+
+const quotes = [
+  'The journey of a thousand miles begins with one step.',
+  'The only limit to our realization of tomorrow is our doubts of today.',
+  'Stay hungry, stay foolish.'
+];
+
+const Hero = () => {
+  const { openEditor } = useDesignContext();
+  const quote = useMemo(
+    () => quotes[Math.floor(Math.random() * quotes.length)],
+    []
+  );
+
+  const socials = [
+    {
+      href: process.env.NEXT_PUBLIC_EMAIL
+        ? `mailto:${process.env.NEXT_PUBLIC_EMAIL}`
+        : '#',
+      label: 'Email',
+      Icon: Mail
+    },
+    {
+      href: process.env.NEXT_PUBLIC_TELEGRAM || '#',
+      label: 'Telegram',
+      Icon: Send
+    },
+    {
+      href: process.env.NEXT_PUBLIC_DISCORD || '#',
+      label: 'Discord',
+      Icon: MessageCircle
+    },
+    {
+      href: process.env.NEXT_PUBLIC_FACEBOOK || '#',
+      label: 'Facebook',
+      Icon: Facebook
+    },
+    {
+      href: process.env.NEXT_PUBLIC_STEAM || '#',
+      label: 'Steam',
+      Icon: Gamepad2
+    },
+    {
+      href: process.env.NEXT_PUBLIC_GITHUB || '#',
+      label: 'GitHub',
+      Icon: Github
+    }
+  ];
+
+  return (
+    <section
+      className="hero"
+      style={{ padding: '4rem 1rem', textAlign: 'center' }}
+    >
+      <h1>Almir</h1>
+      <p className="tagline">Personal space on the web</p>
+      <p className="quote">"{quote}"</p>
+      <div
+        className="socials"
+        style={{
+          marginTop: '1rem',
+          display: 'flex',
+          justifyContent: 'center',
+          gap: '0.5rem'
+        }}
+      >
+        {socials.map(({ href, label, Icon }) => (
+          <a
+            key={label}
+            href={href}
+            aria-label={label}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Icon />
+          </a>
+        ))}
+      </div>
+      <div className="actions" style={{ marginTop: '1rem' }}>
+        <a href="#contact" className="btn" style={{ marginRight: '0.5rem' }}>
+          Contact
+        </a>
+        <button className="btn" onClick={openEditor}>
+          Edit design
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default Hero;
+

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useEffect, useState } from 'react';
+import { DesignContext } from '../context/DesignContext';
 import Link from 'next/link';
 import DesignEditor from './DesignEditor';
 
@@ -42,7 +43,8 @@ const Layout = ({ children }: Props) => {
   const nextTheme = themes[(themes.indexOf(theme) + 1) % themes.length];
 
   return (
-    <>
+    <DesignContext.Provider value={{ openEditor: () => setEditorOpen(true) }}>
+      <>
       <header className="header glass">
         <nav className="nav">
           <span className="logo">Almir</span>
@@ -92,7 +94,8 @@ const Layout = ({ children }: Props) => {
         <p>Built with Next.js</p>
         <a href="/rss.xml">RSS</a>
       </footer>
-    </>
+      </>
+    </DesignContext.Provider>
   );
 };
 

--- a/src/context/DesignContext.tsx
+++ b/src/context/DesignContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+interface DesignContextValue {
+  openEditor: () => void;
+}
+
+export const DesignContext = createContext<DesignContextValue | null>(null);
+
+export const useDesignContext = () => {
+  const ctx = useContext(DesignContext);
+  if (!ctx) {
+    throw new Error('useDesignContext must be used within Layout');
+  }
+  return ctx;
+};
+

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,26 +1,8 @@
 import { NextPage } from 'next';
-import { useMemo } from 'react';
-
-const quotes = [
-  'The journey of a thousand miles begins with one step.',
-  'The only limit to our realization of tomorrow is our doubts of today.',
-  'Stay hungry, stay foolish.'
-];
+import Hero from '../components/Hero';
 
 const Home: NextPage = () => {
-  const quote = useMemo(() => quotes[Math.floor(Math.random() * quotes.length)], []);
-
-  return (
-    <section style={{ padding: '4rem 1rem', textAlign: 'center' }}>
-      <h1>Almir</h1>
-      <p className="tagline">Personal space on the web</p>
-      <p className="quote">"{quote}"</p>
-      <div className="actions" style={{ marginTop: '1rem' }}>
-        <a href="#contact" className="btn" style={{ marginRight: '0.5rem' }}>Contact</a>
-        <button className="btn">Edit design</button>
-      </div>
-    </section>
-  );
+  return <Hero />;
 };
 
 export default Home;

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,6 +258,11 @@ is-arrayish@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.4.tgz#1ee5553818511915685d33bb13d31bf854e5059d"
   integrity sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==
 
+lucide-react@^0.453.0:
+  version "0.453.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.453.0.tgz#d37909a45a29d89680383a202ee861224b05ba6a"
+  integrity sha512-kL+RGZCcJi9BvJtzg2kshO192Ddy9hv3ij+cPrVPWSRzgCWCVazoQJxOjAwgK53NomL07HB7GPHW120FimjNhQ==
+
 nanoid@^3.3.6:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"


### PR DESCRIPTION
## Summary
- implement dedicated Hero component with contact icon buttons and random quote
- expose design editor to child components via context
- document completion of hero task and add lucide icon dependency

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c816e786f88329929e73bf76e89451